### PR TITLE
Fix example: updateShape change creates new shape, schema error for note, createShape create shapes twice

### DIFF
--- a/example/worker/do/openai/getTldrawAiChangesFromSimpleEvents.ts
+++ b/example/worker/do/openai/getTldrawAiChangesFromSimpleEvents.ts
@@ -60,7 +60,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				description: shape.note ?? '',
 				shape: {
 					id: shape.shapeId as any,
-					type: event.type === 'create' ? 'text' : undefined,
+					type: 'text',
 					x: shape.x,
 					y: shape.y,
 					props: {
@@ -69,7 +69,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 						textAlign: shape.textAlign ?? 'middle',
 					},
 				},
-			})
+			} satisfies TLAiChange)
 			break
 		}
 		case 'line': {
@@ -81,7 +81,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				description: shape.note ?? '',
 				shape: {
 					id: shape.shapeId as any,
-					type: event.type === 'create' ? 'line' : undefined,
+					type: 'text',
 					x: minX,
 					y: minY,
 					props: {
@@ -114,7 +114,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				description: shape.note ?? '',
 				shape: {
 					id: shapeId as any,
-					type: event.type === 'create' ? 'arrow' : undefined,
+					type: 'arrow',
 					x: 0,
 					y: 0,
 					props: {
@@ -174,8 +174,8 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				})
 			}
 			break
-        }
-        case 'cloud':
+		}
+		case 'cloud':
 		case 'rectangle':
 		case 'ellipse': {
 			changes.push({
@@ -183,7 +183,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				description: shape.note ?? '',
 				shape: {
 					id: shape.shapeId as any,
-					type: event.type === 'create' ? 'geo' : undefined,
+					type: 'geo',
 					x: shape.x,
 					y: shape.y,
 					props: {
@@ -205,7 +205,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 				description: shape.note ?? '',
 				shape: {
 					id: shape.shapeId as any,
-					type: event.type === 'create' ? 'note' : undefined,
+					type: 'note',
 					x: shape.x,
 					y: shape.y,
 					props: {

--- a/example/worker/do/openai/getTldrawAiChangesFromSimpleEvents.ts
+++ b/example/worker/do/openai/getTldrawAiChangesFromSimpleEvents.ts
@@ -69,7 +69,7 @@ function getTldrawAiChangesFromSimpleCreateOrUpdateEvent(
 						textAlign: shape.textAlign ?? 'middle',
 					},
 				},
-			} satisfies TLAiChange)
+			})
 			break
 		}
 		case 'line': {

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -6,6 +6,7 @@ import type {
 	TLBindingId,
 	TLBindingUpdate,
 	TLContent,
+	TLShape,
 	TLShapeId,
 	TLShapePartial,
 } from 'tldraw'
@@ -53,16 +54,16 @@ export interface TLAiSerializedPrompt extends Omit<TLAiPrompt, 'contextBounds' |
 	promptBounds: BoxModel
 }
 
-export interface CreateShapeChange {
+export interface CreateShapeChange<T extends TLShape = TLShape> {
 	type: 'createShape'
 	description: string
-	shape: TLShapePartial
+	shape: TLShapePartial<T>
 }
 
-export interface UpdateShapeChange {
+export interface UpdateShapeChange<T extends TLShape = TLShape> {
 	type: 'updateShape'
 	description: string
-	shape: Omit<TLShapePartial, 'type'>
+	shape: Omit<TLShapePartial<T>, 'type'> & { type?: T['type'] } // type is optional
 }
 
 export interface DeleteShapeChange {

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -54,37 +54,37 @@ export interface TLAiSerializedPrompt extends Omit<TLAiPrompt, 'contextBounds' |
 	promptBounds: BoxModel
 }
 
-export interface CreateShapeChange<T extends TLShape = TLShape> {
+export interface TLAiCreateShapeChange<T extends TLShape = TLShape> {
 	type: 'createShape'
 	description: string
 	shape: TLShapePartial<T>
 }
 
-export interface UpdateShapeChange<T extends TLShape = TLShape> {
+export interface TLAiUpdateShapeChange<T extends TLShape = TLShape> {
 	type: 'updateShape'
 	description: string
 	shape: Omit<TLShapePartial<T>, 'type'> & { type?: T['type'] } // type is optional
 }
 
-export interface DeleteShapeChange {
+export interface TLAiDeleteShapeChange {
 	type: 'deleteShape'
 	description: string
 	shapeId: TLShapeId
 }
 
-export interface CreateBindingChange {
+export interface TLAiCreateBindingChange<B extends TLBinding = TLBinding> {
 	type: 'createBinding'
 	description: string
-	binding: TLBindingCreate
+	binding: TLBindingCreate<B>
 }
 
-export interface UpdateBindingChange {
+export interface TLAiUpdateBindingChange<B extends TLBinding = TLBinding> {
 	type: 'updateBinding'
 	description: string
-	binding: TLBindingUpdate
+	binding: TLBindingUpdate<B>
 }
 
-export interface DeleteBindingChange {
+export interface TLAiDeleteBindingChange {
 	type: 'deleteBinding'
 	description: string
 	bindingId: TLBindingId
@@ -94,12 +94,12 @@ export interface DeleteBindingChange {
  * A generated change that can be applied to the editor.
  */
 export type TLAiChange =
-	| CreateShapeChange
-	| UpdateShapeChange
-	| DeleteShapeChange
-	| CreateBindingChange
-	| UpdateBindingChange
-	| DeleteBindingChange
+	| TLAiCreateShapeChange
+	| TLAiUpdateShapeChange
+	| TLAiDeleteShapeChange
+	| TLAiCreateBindingChange
+	| TLAiUpdateBindingChange
+	| TLAiDeleteBindingChange
 
 export type TLAiContent = Omit<TLContent, 'schema' | 'rootShapeIds'> & {
 	bindings: TLBinding[]


### PR DESCRIPTION
## 🔎 What / why

Fix the following:
- updateShape change creates new shapes instead of changing existing ones.
- notes are not created due to `geo` props (one-line change)
- createShape creates 2 shapes for every event. (see comments)